### PR TITLE
Add Vive OpenXR runtime to the list

### DIFF
--- a/src/common/xr_runtimes.txt
+++ b/src/common/xr_runtimes.txt
@@ -2,3 +2,4 @@ windows WMR C:\WINDOWS\system32\MixedRealityRuntime.json
 windows Oculus C:\Program Files\Oculus\Support\oculus-runtime\oculus_openxr_64.json
 windows SteamVR C:\Program Files (x86)\Steam\steamapps\common\SteamVR\steamxr_win64.json
 windows Varjo C:\Program Files\Varjo\varjo-openxr\VarjoOpenXR.json
+windows ViveOpenXR C:\Program Files (x86)\VIVE\Updater\App\ViveVRRuntime\ViveVR_openxr\ViveOpenXR.json


### PR DESCRIPTION
This MR adds to the xr_runtimes.txt list the default installation path for the VIVE Cosmos OpenXR runtime