### PR TITLE
Fix chaining issue in openxr_load_properties()

### DIFF
--- a/src/openxrexplorer/openxr_info.cpp
+++ b/src/openxrexplorer/openxr_info.cpp
@@ -379,12 +379,12 @@ xr_properties_t openxr_load_properties() {
 		result.hand_mesh            .next = &result.gaze;
 		result.gaze                 .next = &result.foveated_varjo;
 		result.foveated_varjo       .next = &result.color_space_fb;
-		result.facial_tracking_htc  .next = &result.foveated_varjo;
-		result.keyboard_tracking_fb .next = &result.facial_tracking_htc;
-		result.marker_tracking_varjo.next = &result.keyboard_tracking_fb;
-		result.passthrough_fb       .next = &result.marker_tracking_varjo;
-		result.render_model_fb      .next = &result.passthrough_fb;
-		result.space_warp_fb        .next = &result.render_model_fb;
+		result.color_space_fb       .next = &result.facial_tracking_htc;
+		result.facial_tracking_htc  .next = &result.keyboard_tracking_fb;
+		result.keyboard_tracking_fb .next = &result.marker_tracking_varjo;
+		result.marker_tracking_varjo.next = &result.passthrough_fb;
+		result.passthrough_fb       .next = &result.render_model_fb;
+		result.render_model_fb      .next = &result.space_warp_fb;
 
 		XrResult error = xrGetSystemProperties(xr_instance, xr_system_id, &result.system);
 		if (XR_FAILED(error)) {


### PR DESCRIPTION
Looking through this chain, it seems like it converges on `.foveated_varjo` from two directions:

1. The normal chain from `.system` down, ending with a link from `.foveated_varjo` to `.color_space_fb`
2. A chain from the bottom of this list, from `.space_warp_fb` up through to `.foveated_varjo`

`.space_warp_fb` doesn't appear to be chained to anything, so, as far as I can tell, this chain seems like it won't be passed into the `xrGetSystemProperties` call.

Please let me know if I'm reading this wrong or missing something! I don't have a headset with me that might resolve any of these, so I'm currently unable to test the actual resolution. I should be able to test on Tuesday though!