### PR TITLE
Add build validation via GitHub Actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,3 +29,21 @@ jobs:
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel 8
+
+    - name: Pack
+      run: |
+        if ("${{ matrix.os }}" -eq "windows-latest") {
+          $fileName = "openxr-explorer-win-x64.zip"
+          $paths = $(Join-Path "build" "Release" "openxr-explorer.exe"), $(Join-Path "build" "Release" "xrsetruntime.exe")
+        } else {
+          $fileName = "openxr-explorer-linux-x64.zip"
+          $paths = $(Join-Path "build" "openxr-explorer"), $(Join-Path "build" "xrsetruntime")
+        }
+        Compress-Archive -Force -Path $paths -DestinationPath $fileName
+      shell: pwsh
+
+    - name: Publish
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }}
+        path: "*.zip"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,27 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel 8

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install Linux Dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install libxcb-keysyms1-dev libxcb1-dev libxcb-xfixes0-dev libxcb-cursor-dev libxcb-xkb-dev libxcb-glx0-dev libxcb-randr0-dev libx11-xcb-dev libglew-dev
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ openxr-explorer.exe
 #### Linux
 Pre-requisites (partial)
 ```
-sudo apt-get install libxcb-keysyms1-dev libxcb1-dev libxcb-xfixes0-dev libxcb-cursor-dev libxcb-xkb-dev libxcb-glx0-dev libxcb-randr0-dev libx11-xcb-dev
+sudo apt-get install libxcb-keysyms1-dev libxcb1-dev libxcb-xfixes0-dev libxcb-cursor-dev libxcb-xkb-dev libxcb-glx0-dev libxcb-randr0-dev libx11-xcb-dev libglew-dev
 ```
 
 From the root directory:


### PR DESCRIPTION
Adds support for building, packing, and publishing artifacts in both PRs and on merges. For the most part, I used a combination of the commands in the README and `buildrelease.bat`, with some minor changes to the `cmake` pattern. I also found a dependency I needed to install for Linux that wasn't in the README, so I added it.

A successful test run can be found at https://github.com/keveleigh/openxr-explorer/actions/runs/2481916369 (since it looks like this PR won't run it, since it's not my repo, which makes sense!!)

![image](https://user-images.githubusercontent.com/3580640/173210700-13a845eb-ff2d-4c5d-94d3-fd60b1ef530f.png)
