### PR TITLE
Do not sort API layers

### DIFF
--- a/src/openxrexplorer/openxr_info.cpp
+++ b/src/openxrexplorer/openxr_info.cpp
@@ -295,15 +295,15 @@ xr_extensions_t openxr_load_exts() {
 	}
 	xr_tables.add(table);
 
-	// Load and sort layers
+	// Load layers.
+	//
+	// Layers are not sorted because the order is important; for example, layers that
+	// use an extension should be before layers that provide the extension.
 	count = 0;
 	if (XR_FAILED(xrEnumerateApiLayerProperties(0, &count, nullptr)))
 		return result;
 	result.layers = array_t<XrApiLayerProperties>::make_fill(count, {XR_TYPE_API_LAYER_PROPERTIES});
 	xrEnumerateApiLayerProperties(count, &count, result.layers.data);
-	result.layers.sort([](const XrApiLayerProperties &a, const XrApiLayerProperties &b) {
-		return strcmp(a.layerName, b.layerName);
-	});
 
 	table = {};
 	table.name_func = "xrEnumerateApiLayerProperties";


### PR DESCRIPTION
Order is important; for example, layers using an extension should be before layers that provide that extension.

While the order is technically undefined, it is important, and - at least on Windows - predictable: API layers are returned (and loaded) in the order provided by `RegEnumValue()`. This is explicitly unordered, however in practice, that is reliably the order in which values were created, i.e. layer installation order unless installation scripts manipulate the order.

# Before (with [another tool](https://github.com/fredemmott/OpenXR-API-Layers-GUI) showing the actual order and known issues)

![before](https://github.com/maluoi/openxr-explorer/assets/360927/a0b9d481-f8f0-4c9d-b48f-d607070fa8ac)

# After

![after](https://github.com/maluoi/openxr-explorer/assets/360927/8ff4342a-45ff-4d81-b020-4b523582e423)
