### PR TITLE
Enumerate runtimes on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if (UNIX)
   # Android, static linking is necessary.
   set(CPM_USE_LOCAL_PACKAGES ON) # Tell CPM to prefer locally installed packages
 endif()
+include(cmake/json.cmake)
 
 add_subdirectory(src)
 

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -1,0 +1,12 @@
+set(NLOHMANN_JSON_DOWNLOAD_VERSION 3.11.3)
+
+set(NLOHMANN_JSON_INCLUDE_DIR "${CMAKE_BINARY_DIR}/cmake/nlohamn-json-${NLOHMANN_JSON_DOWNLOAD_VERSION}/include/")
+set(NLOHMANN_JSON_DOWNLOAD_LOCATION "${NLOHMANN_JSON_INCLUDE_DIR}/nlohmann/json.hpp")
+if (NOT (EXISTS ${NLOHMANN_JSON_DOWNLOAD_LOCATION}))
+    file(
+        DOWNLOAD
+        "https://github.com/nlohmann/json/releases/download/v${NLOHMANN_JSON_DOWNLOAD_VERSION}/json.hpp"
+        ${NLOHMANN_JSON_DOWNLOAD_LOCATION}
+    )
+endif()
+include_directories(${NLOHMANN_JSON_INCLUDE_DIR})

--- a/src/common/xrruntime.cpp
+++ b/src/common/xrruntime.cpp
@@ -6,6 +6,14 @@
 #include <malloc.h>
 #include <sys/stat.h>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
+#include <nlohmann/json.hpp>
+
 /*** Default Runtime File ****************/
 
 #include "xr_runtime_default.h"
@@ -14,29 +22,14 @@
 /*** Signatures **************************/
 
 bool file_exists(const char *file);
+char* read_file(const char* file);
 
 /*** Code ********************************/
 
 bool load_runtimes(const char *file, runtime_t **out_runtime_list, int32_t *out_runtime_count) {
 	const char *files[3]  = {};
-	FILE       *fp        = nullptr;
-	char       *file_data = nullptr;
-	fp = fopen(file, "r");
-	if (fp != nullptr) {
-		// Get length of file
-		fseek(fp, 0, SEEK_END);
-		size_t size = ftell(fp);
-		fseek(fp, 0, SEEK_SET);
-
-		// Read the data
-		file_data = (char*)malloc(size+1);
-		fread (file_data, 1, size, fp);
-		fclose(fp);
-
-		// Stick an end string 0 character at the end in case the caller wants
-		// to treat it like a string
-		file_data[size] = 0;
-
+	char       *file_data = read_file(file);
+	if (file_data != nullptr) {
 		files[0] = file_data;
 		files[1] = runtime_default_list;
 	} else {
@@ -91,6 +84,38 @@ bool load_runtimes(const char *file, runtime_t **out_runtime_list, int32_t *out_
 
 	#if defined(_WIN32)
 	platform_ curr_platform = platform_windows;
+	HKEY available_runtimes_key {};
+	if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Khronos\\OpenXR\\1\\AvailableRuntimes", 0, KEY_READ, &available_runtimes_key) == ERROR_SUCCESS && available_runtimes_key) {
+		// The actual limit is 16383 based on the registry limits:
+		//   https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-element-size-limits
+		// However, we'll stick to 1024 (including terminating null) as we need to fit in
+		// runtime_t::file
+		char path[1024];
+		// If we end up switching to wchar, this will still be a character count, not a byte count
+		DWORD path_char_count = sizeof(path);
+		DWORD value_type;
+		DWORD disabled;
+		DWORD disabled_byte_count = sizeof(disabled);
+		for (DWORD i=0; ;++i) {
+			auto res = RegEnumValueA(available_runtimes_key, i, path, &path_char_count, nullptr, &value_type, reinterpret_cast<LPBYTE>(&disabled), &disabled_byte_count);
+			if (res == ERROR_NO_MORE_ITEMS) {
+				break;
+			}
+			if (res == ERROR_SUCCESS && value_type == REG_DWORD) {
+				result_count += 1;
+				result_list = (runtime_t*)realloc(result_list, sizeof(runtime_t) * result_count);
+				auto& runtime = result_list[result_count - 1];
+				runtime.platform = curr_platform;
+				runtime.name[0] = 0;
+				memcpy(runtime.file, path, path_char_count);
+				runtime.file[path_char_count] = '\0';
+				runtime.present = file_exists(runtime.file) && !disabled;
+			}
+			path_char_count = sizeof(path);
+			disabled_byte_count = sizeof(disabled);
+		}
+		RegCloseKey(available_runtimes_key);
+	}
 	#elif defined(__linux)
 	platform_ curr_platform = platform_linux;
 
@@ -107,6 +132,56 @@ bool load_runtimes(const char *file, runtime_t **out_runtime_list, int32_t *out_
 		}
 	}
 	#endif
+	for (int32_t i=0; i<result_count; i+=1) {
+		auto& runtime = result_list[i];
+		if (runtime.name[0] || !file_exists(runtime.file)) {
+			continue;
+		}
+
+		// Try to read the name rom the JSON
+		auto json = read_file(runtime.file);
+		if (!json) {
+			continue;
+		}
+		try {
+			const auto manifest = nlohmann::json::parse(json);
+			free(json);	
+			json = nullptr;
+			if (manifest.contains("runtime")) {
+				const auto& runtime_metadata = manifest.at("runtime");
+				if (runtime_metadata.contains("name")) {
+					const auto& name = runtime_metadata.at("name");
+					if (name.is_string()) {
+						auto str = name.get<std::string>();
+						// Include trailing null in copy
+						if (str.size() + 1 <= sizeof(runtime.name)) {
+							memcpy(runtime.name, str.c_str(), str.size() + 1);
+						}
+					}
+				}
+			}
+		} catch (const nlohmann::json::exception&) {
+			if (json) {
+				free(json);
+			}
+		}
+
+		if (runtime.name[0]) {
+			continue;
+		}
+
+		// "name" is an optional field in the manifest, so might be legitimately be missing,
+		// or we might have had a failure. If so, let's try and put *something* there
+		auto basename_start = strrchr(runtime.file, '\\');
+		auto basename_end = strrchr(runtime.file, '.');
+		if (basename_start && basename_end > basename_start) {
+			basename_start++;
+			memcpy(runtime.name, basename_start, basename_end - basename_start);
+			runtime.name[basename_end - basename_start] = '\0';
+		} else {
+			memcpy(runtime.name, "Unknown", sizeof("Unknown"));
+		}
+	}
 
 	for (int32_t i=0; i<result_count; i+=1) {
 		// See if there's an earlier one
@@ -174,4 +249,30 @@ const char *runtime_config_path() {
 bool file_exists(const char *file) {
 	struct stat buffer;   
 	return (stat (file, &buffer) == 0);
+}
+
+char* read_file(const char* file) {
+	FILE* fp = fopen(file, "r");
+	if (!fp) {
+		return nullptr;
+	}
+
+	// Get length of file
+	fseek(fp, 0, SEEK_END);
+	size_t size = ftell(fp);
+	fseek(fp, 0, SEEK_SET);
+
+	// Read the data
+	char* file_data = (char*)malloc(size+1);
+	char* it = file_data;
+	size_t bytes_to_read = size;
+	while (size_t bytes_read = fread(it, 1, bytes_to_read, fp)) {
+		bytes_to_read -= bytes_read;
+		it += bytes_read;
+	}
+	// Stick an end string 0 character at the end in case the caller wants
+	// to treat it like a string
+	*it = '\0';
+	fclose(fp);
+	return file_data;
 }


### PR DESCRIPTION
fixes #4

This is combined with the existing hard-coded list. I've mostly stuck to C APIs rather than e.g. `std::string` to copy the existing style of the code.

It is not possible to set "VirtualDesktopXR (Bundled)" as the runtime, probably because it includes spaces. Will fix separately.

![image](https://github.com/maluoi/openxr-explorer/assets/360927/95524a6b-e312-4bf6-a38a-007a8e0d5adf)

![image](https://github.com/maluoi/openxr-explorer/assets/360927/3e9355c3-3163-4981-8f60-4bba5949bf4d)
