### PR TITLE
Fix build with -Werror=format-security

### DIFF
--- a/src/openxrexplorer/main.cpp
+++ b/src/openxrexplorer/main.cpp
@@ -139,7 +139,7 @@ void app_window_runtime() {
 	ImGui::Separator();
 	ImGui::Spacing();
 
-	ImGui::Text(xr_runtime_name);
+	ImGui::Text("%s", xr_runtime_name);
 
 	// Runtime picker
 	if (ImGui::BeginCombo("##Change Runtime", current_runtime == -1 ? "Change Runtime" : runtimes[current_runtime].name)) {


### PR DESCRIPTION
In the Arch Linux AUR the `-Werror=format-security` flag is on by default, which causes the build to fail with the following error:
```
/home/code/openxr-explorer/src/openxrexplorer/main.cpp: In function ‘void app_window_runtime()’:
/home/code/openxr-explorer/src/openxrexplorer/main.cpp:142:20: error: format not a string literal and no format arguments [-Werror=format-security]
  142 |         ImGui::Text(xr_runtime_name);
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```
This fixes the warning and lets it build. To test I built with:
```
cmake -Bbuild -DCMAKE_CXX_FLAGS="-Wformat -Werror=format-security"
make -C build
```