### PR TITLE
Update xr_runtime_default.h

### DIFF
--- a/src/common/xr_runtime_default.h
+++ b/src/common/xr_runtime_default.h
@@ -11,5 +11,7 @@ windows Oculus C:\Program Files\Oculus\Support\oculus-runtime\oculus_openxr_64.j
 windows SteamVR C:\Program Files (x86)\Steam\steamapps\common\SteamVR\steamxr_win64.json
 windows Varjo C:\Program Files\Varjo\varjo-openxr\VarjoOpenXR.json
 windows ViveOpenXR C:\Program Files (x86)\VIVE\Updater\App\ViveVRRuntime\ViveVR_openxr\ViveOpenXR.json
+windows VirtualDesktopXRBundled C:\Program Files\Virtual Desktop Streamer\OpenXR\virtualdesktop-openxr-32.json
+windows VirtualDesktopXRStandalone C:\Program Files\VirtualDesktopXR\virtualdesktop-openxr-32.json
 linux Monado /usr/share/openxr/1/openxr_monado.json
 linux SteamVR ~/.steam/steam/steamapps/common/SteamVR/steamxr_linux64.json)_";


### PR DESCRIPTION
added VDXR, both bundled (included with Virtual Desktop) and standalone for link/airlink for Quest headsets