### PR TITLE
🐛 Fall back to OpenXR 1.0 if XR_CURRENT_API_VERSION in unsupported

### DIFF
--- a/src/openxrexplorer/openxr_info.cpp
+++ b/src/openxrexplorer/openxr_info.cpp
@@ -184,6 +184,10 @@ void openxr_init_instance(array_t<XrExtensionProperties> extensions) {
 	snprintf(create_info.applicationInfo.engineName,      sizeof(create_info.applicationInfo.engineName     ), "None");
 	
 	XrResult result = xrCreateInstance(&create_info, &xr_instance);
+	if (result == XR_ERROR_API_VERSION_UNSUPPORTED) {
+		create_info.applicationInfo.apiVersion = XR_API_VERSION_1_0;
+		result = xrCreateInstance(&create_info, &xr_instance);
+	}
 	if (XR_FAILED(result)) {
 		xr_instance_err = openxr_result_string(result);
 		xr_system_err   = "No XrInstance available";


### PR DESCRIPTION
There are not yet *any* officially conformant 1.1 PCVR runtimes - the only two 1.1 runtimes are for Snapdragon-based devices: https://www.khronos.org/conformance/adopters/conformant-products/openxr

The code as-is will fail for most 'correct' runtimes. It will currently succeed for runtimes that either:

- have fully or partially implemented OpenXR 1.1 but not obtained official conformant status
- have not correctly implemetned the API version check

Fixes things under Meta XR Simulator.
Fixes #34